### PR TITLE
feat: Generate multiple SARI score confidence intervals for different test set using bootstrap resampling

### DIFF
--- a/scripts/eval_text_with_all_metrics.py
+++ b/scripts/eval_text_with_all_metrics.py
@@ -20,6 +20,29 @@ from bert_score import score
 import warnings
 warnings.filterwarnings("ignore")
 
+def generate_sari_scores(original_sentences, simplified_sentences, reference_sentences, iterations=1000, sample_size=100):
+    """
+    Generate multiple SARI scores using bootstrapping.
+    
+    :param original_sentences: List of original sentences.
+    :param simplified_sentences: List of simplified sentences.
+    :param reference_sentences: List of reference sentences.
+    :param iterations: Number of bootstrap samples to generate.
+    :param sample_size: Number of sentences to sample in each bootstrap sample.
+    :return: List of SARI scores.
+    """
+    sari_scores = []
+    for _ in range(iterations):
+        indices = np.random.choice(len(original_sentences), sample_size, replace=True)
+        sampled_originals = [original_sentences[idx] for idx in indices]
+        sampled_simplifications = [simplified_sentences[idx] for idx in indices]
+        sampled_references = [reference_sentences[idx] for idx in indices]
+        
+        score = corpus_sari(orig_sents=sampled_originals, sys_sents=sampled_simplifications, refs_sents=[sampled_references])
+        sari_scores.append(score)
+    
+    return sari_scores
+
 if __name__ == '__main__':
     """# 1. Prepare Data"""
     print(torch.__version__)
@@ -58,6 +81,10 @@ if __name__ == '__main__':
         assert len(simple_seq) == len(ref_seq[9])
     
     assert len(simple_seq) == len(src_seq)
+
+    sari_scores = generate_sari_scores(src_seq, simple_seq, ref_seq)
+    print(f"Generated SARI scores: {sari_scores[:10]}...")  # Print *only* first 10 scores
+
     results={}
     results['sari'] = corpus_sari(orig_sents=src_seq,
                        sys_sents=simple_seq,

--- a/scripts/eval_text_with_all_metrics.py
+++ b/scripts/eval_text_with_all_metrics.py
@@ -20,28 +20,56 @@ from bert_score import score
 import warnings
 warnings.filterwarnings("ignore")
 
-def generate_sari_scores(original_sentences, simplified_sentences, reference_sentences, iterations=1000, sample_size=100):
+def generate_sari_confidence_intervals(original_sentences, simplified_sentences, reference_sentences, iterations=1000, total_test_sets=100):
     """
-    Generate multiple SARI scores using bootstrapping.
+    Generate multiple SARI score confidence intervals for different test set using bootstrap resampling.
     
-    :param original_sentences: List of original sentences.
-    :param simplified_sentences: List of simplified sentences.
-    :param reference_sentences: List of reference sentences.
-    :param iterations: Number of bootstrap samples to generate.
-    :param sample_size: Number of sentences to sample in each bootstrap sample.
-    :return: List of SARI scores.
+    Parameters:
+    - original_sentences: List of original sentences.
+    - simplified_sentences: List of simplified sentences.
+    - reference_sentences: List of reference sentences.
+    - iterations: Number of bootstrap samples to generate per test sets.
+    - total_test_sets: Number of different test set to evaluate.
+    
+    Returns:
+    - List of confidence intervals for each test sets.
     """
-    sari_scores = []
-    for _ in range(iterations):
-        indices = np.random.choice(len(original_sentences), sample_size, replace=True)
-        sampled_originals = [original_sentences[idx] for idx in indices]
-        sampled_simplifications = [simplified_sentences[idx] for idx in indices]
-        sampled_references = [reference_sentences[idx] for idx in indices]
-        
-        score = corpus_sari(orig_sents=sampled_originals, sys_sents=sampled_simplifications, refs_sents=[sampled_references])
-        sari_scores.append(score)
+    all_intervals = []
     
-    return sari_scores
+    for _ in range(total_test_sets):
+        sari_scores = []
+        for __ in range(iterations):
+            indices = np.random.choice(len(original_sentences), len(original_sentences), replace=True)
+            sampled_originals = [original_sentences[i] for i in indices]
+            sampled_simplifications = [simplified_sentences[i] for i in indices]
+
+            # verify if reference_sentences is a flat list or a list of list
+            if isinstance(reference_sentences[0], list):
+                sampled_references = [reference_sentences[i] for i in indices] # Please, review @arthur
+            else:
+                sampled_references = [[reference_sentences[i]] for i in indices]
+
+            score = corpus_sari(orig_sents=sampled_originals, sys_sents=sampled_simplifications, refs_sents=sampled_references)
+            sari_scores.append(score)
+
+        sari_scores.sort()
+        # calculate the indices for the 2.5th and 97.5th %
+        lower_index = max(0, int(0.025 * len(sari_scores)))
+        upper_index = min(len(sari_scores) - 1, int(0.975 * len(sari_scores)))
+
+        all_intervals.append((sari_scores[lower_index], sari_scores[upper_index]))
+
+    return all_intervals
+
+def plot_sari_confidence_intervals(all_intervals):
+    """
+    Plot the SARI score confidence intervals.
+    
+    Parameters:
+    - all_intervals: List of tuples representing the confidence intervals.
+    """
+    #TODO
+    pass
 
 if __name__ == '__main__':
     """# 1. Prepare Data"""
@@ -61,7 +89,7 @@ if __name__ == '__main__':
     }
     if 'asset' not in dataset:        
         with open(config['evaluate_kwargs']['refs_sents_paths'][0], 'r') as f1, open(config['simplifications_path'], 'r') as f2, open(config['evaluate_kwargs']['orig_sents_path'], 'r') as f3:
-            ref_seq = f1.readlines()    
+            ref_seq = f1.readlines()
             simple_seq = f2.readlines()
             src_seq = f3.readlines()
     else:
@@ -82,19 +110,21 @@ if __name__ == '__main__':
     
     assert len(simple_seq) == len(src_seq)
 
-    sari_scores = generate_sari_scores(src_seq, simple_seq, ref_seq)
-    print(f"Generated SARI scores: {sari_scores[:10]}...")  # Print *only* first 10 scores
+    sari_bootstrap_resampling_intervals = generate_sari_confidence_intervals(src_seq, simple_seq, ref_seq)
+    print(f"Generated SARI score confidence intervals: {sari_bootstrap_resampling_intervals[:10]}...")  # Print *only* first 10 intervals
+    plot_sari_confidence_intervals(sari_bootstrap_resampling_intervals)
 
     results={}
-    results['sari'] = corpus_sari(orig_sents=src_seq,
-                       sys_sents=simple_seq,
-                       refs_sents=[ref_seq])
     results['bleu'] = corpus_bleu(sys_sents=simple_seq,
                        refs_sents=[ref_seq],
                        lowercase=True)
     if 'asset' in dataset:
+        results['sari'] = corpus_sari(orig_sents=src_seq, sys_sents=simple_seq, refs_sents=ref_seq) # Please, review @arthur
         P, R, F1 = score(simple_seq, list(map(list, zip(*ref_seq))), lang = 'pt', verbose = True)
     else:
+        # refs_sents should be a "list of list of reference sentences (shape = (n_references, n_samples))
+        # https://github.com/feralvam/easse/blob/6a4352ec299ed03fda8ee45445ca43d9c7673e89/easse/sari.py#L242C5-L242C88
+        results['sari'] = corpus_sari(orig_sents=src_seq, sys_sents=simple_seq, refs_sents=[[ref] for ref in ref_seq])
         P, R, F1 = score(simple_seq, ref_seq, lang = 'pt', verbose = True)
     results['bert_score'] = F1.mean()
     results['outputs_unchanged'] = get_outputs_unchanged(simple_seq,src_seq)


### PR DESCRIPTION
Following the "5. Bootstrap Resampling" in [Statistical Significance Tests for Machine Translation Evaluation](https://www.researchgate.net/publication/221013020_Statistical_Significance_Tests_for_Machine_Translation_Evaluation)

obs: [corpus_sari function](https://github.com/feralvam/easse/blob/6a4352ec299ed03fda8ee45445ca43d9c7673e89/easse/sari.py#L242C5-L242C88)